### PR TITLE
remove depreacted theme_image()

### DIFF
--- a/semanticscuttle/init.php
+++ b/semanticscuttle/init.php
@@ -74,7 +74,7 @@ class SemanticScuttle extends Plugin {
 	function hook_article_button($line) {
 		$article_id = $line["id"];
 
-		$rv = "<img src=\"".theme_image($this->link, 'plugins/semanticscuttle/semanticscuttle.png')."\"
+		$rv = "<img src=\"plugins/semanticscuttle/semanticscuttle.png\"
 			class='tagsPic' style=\"cursor : pointer\"
 			onclick=\"shareArticleToSemanticScuttle($article_id)\"
 			title='".__('Share on SemanticScuttle')."'>";

--- a/semanticscuttle/init.php
+++ b/semanticscuttle/init.php
@@ -18,7 +18,7 @@ class SemanticScuttle extends Plugin {
 	}
 
 	function save() {
-		$semanticscuttle_url = db_escape_string($_POST["semanticscuttle_url"]);
+		$semanticscuttle_url = db_escape_string($this->link, $_POST["semanticscuttle_url"]);
     		$this->host->set($this, "semanticscuttle", $semanticscuttle_url);
 		echo "Value set to $semanticscuttle_url";
 	}
@@ -83,7 +83,7 @@ class SemanticScuttle extends Plugin {
 	}
 
 	function getSemanticScuttle() {
-		$id = db_escape_string($_REQUEST['id']);
+		$id = db_escape_string($this->link, $_REQUEST['id']);
 
 		$result = db_query($this->link, "SELECT title, link
 				FROM ttrss_entries, ttrss_user_entries


### PR DESCRIPTION
I have modify the method calling theme_image() so that it doesn't produce the fatal error anymore.  theme_image() is deprecated in 1.7.5.  There also a minor fix so that the plugin should work with 1.7.8
